### PR TITLE
Add automatic image builder pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,4 +41,6 @@ jobs:
           add: 'Dockerfile'
           message: 'v${{ env.version }}'
           new_branch: 'v${{ env.version }}'
-          tag: 'v${{ env.version }}'
+          # Tags are only really used by this script currently
+          # remove the "v" to prevent collision with branch name
+          tag: '${{ env.version }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update version in code
         run: sed "s/ENV VERSION .*/ENV VERSION ${{ env.version }}/" -i Dockerfile
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build image
         run: |
           docker pull node:alpine
-          docker build -t irgendwr/hugo:${{ env.version }} .
-          docker push irgendwr/hugo:${{ env.version }}
+          docker build -t nightoo/hugo:${{ env.version }} .
+          docker push nightoo/hugo:${{ env.version }}
       - name: Add & Commit
         uses: EndBug/add-and-commit@v9.1.4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,17 +28,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build image
-        run: |
-          docker pull node:alpine
-          docker build -t nightoo/hugo:${{ env.version }} .
-          docker push nightoo/hugo:${{ env.version }}
       - name: Add & Commit
         uses: EndBug/add-and-commit@v9.1.4
         with:
           add: 'Dockerfile'
           message: 'v${{ env.version }}'
           new_branch: 'v${{ env.version }}'
-          # Tags are only really used by this script currently
-          # remove the "v" to prevent collision with branch name
-          tag: '${{ env.version }}'
+      - name: Build image
+        run: |
+          docker pull node:alpine
+          docker build -t nightoo/hugo:${{ env.version }} .
+          docker push nightoo/hugo:${{ env.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update version in code
-        run: sed "s/ENV VERSION .*/ENV VERSION ${{ env.version }}/" -i Dockerfile
+        run: sed "s/FROM ghcr\.io\/gohugoio\/hugo:v.*/FROM ghcr\.io\/gohugoio\/hugo:v${{ env.version }}/" -i Dockerfile
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
@@ -36,6 +36,5 @@ jobs:
           new_branch: 'v${{ env.version }}'
       - name: Build image
         run: |
-          docker pull node:alpine
           docker build -t nightoo/hugo:${{ env.version }} .
           docker push nightoo/hugo:${{ env.version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Determine latest un-imaged version
-        run: |
-          python get_latest_new_release.py
-          echo "version=$(cat _version.txt)" >> $GITHUB_ENV
+        run: GH_TOKEN=${{ secrets.GITHUB_TOKEN }} python get_latest_new_release.py >> $GITHUB_ENV
       - name: Quit if no new version
         run: |
           if [ "${{ env.version }}" = "NONE" ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,39 @@
+name: Build Release Image
+
+on:
+  workflow_dispatch:
+  # Run every day at 5:40.
+  schedule:
+    - cron:  '40 5 * * *'
+jobs:
+  buildflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Determine latest un-imaged version
+        run: |
+          python get_latest_new_release.py
+          echo "version=$(cat _version.txt)" >> $GITHUB_ENV
+      - name: Quit if no new version
+        run: |
+          if [ "${{ env.version }}" = "NONE" ]; then
+            gh run cancel ${{ github.run_id }}
+            gh run watch ${{ github.run_id }}
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update version in code
+        run: sed "s/ENV VERSION .*/ENV VERSION ${{ env.version }}/" -i Dockerfile
+      - name: Build image
+        run: |
+          docker pull node:alpine
+          docker build -t irgendwr/hugo:${{ env.version }} .
+          docker push irgendwr/hugo:${{ env.version }}
+      - name: Add & Commit
+        uses: EndBug/add-and-commit@v9.1.4
+        with:
+          add: 'Dockerfile'
+          message: 'v${{ env.version }}'
+          new_branch: 'v${{ env.version }}'
+          tag: 'v${{ env.version }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,5 @@ jobs:
           new_branch: 'v${{ env.version }}'
       - name: Build image
         run: |
-          docker build -t nightoo/hugo:${{ env.version }} .
-          docker push nightoo/hugo:${{ env.version }}
+          docker build -t irgendwr/hugo:${{ env.version }} .
+          docker push irgendwr/hugo:${{ env.version }}

--- a/get_latest_new_release.py
+++ b/get_latest_new_release.py
@@ -11,7 +11,7 @@ def make_comparable(version_string: str) -> list[int]:
 
 ENDPOINT_HUGO_IMAGES = "https://ghcr.io/v2/gohugoio/hugo/tags/list"
 ENDPOINT_OUR_TAGS = (
-    "https://hub.docker.com/v2/namespaces/nightoo/repositories/hugo/tags"
+    "https://hub.docker.com/v2/namespaces/irgendwr/repositories/hugo/tags"
 )
 
 version_regex = re.compile("([0-9]+\\.){2}[0-9]+")

--- a/get_latest_new_release.py
+++ b/get_latest_new_release.py
@@ -46,4 +46,4 @@ else:
     minimum_new_version = "NONE"
     print("No new release found, stopping.", file=stderr)
 
-print(minimum_new_version.replace("v", ""))
+print("version=", minimum_new_version.replace("v", ""), sep="")

--- a/get_latest_new_release.py
+++ b/get_latest_new_release.py
@@ -22,7 +22,7 @@ try:
     latest_tag = res.json()[0]["name"]
     print("Checking for releases older than", latest_tag, file=stderr)
 except IndexError:
-    latest_tag = None
+    latest_tag = "v1.0.0.0"
     print("No tags found, starting with newest Hugo release", file=stderr)
 
 

--- a/get_latest_new_release.py
+++ b/get_latest_new_release.py
@@ -10,40 +10,40 @@ def make_comparable(version_string: str) -> list[int]:
 
 
 ENDPOINT_HUGO_IMAGES = "https://ghcr.io/v2/gohugoio/hugo/tags/list"
-ENDPOINT_MY_TAGS = (
-    "https://api.github.com/repos/DeinAlptraum/docker-hugo/tags?per_page=1"
+ENDPOINT_OUR_TAGS = (
+    "https://hub.docker.com/v2/namespaces/nightoo/repositories/hugo/tags"
 )
 
-request_counter = 1
+our_tags = set()
+try_next_page = True
+current_url = ENDPOINT_OUR_TAGS
+while try_next_page:
+    print("Retrieving tags at", current_url, file=stderr)
+    content = requests.get(current_url).json()
+    our_tags = our_tags.union([image["name"] for image in content["results"]])
 
-# Check the latest release we've done
-res = requests.get(ENDPOINT_MY_TAGS)
-try:
-    latest_tag = res.json()[0]["name"]
-    print("Checking for releases older than", latest_tag, file=stderr)
-except IndexError:
-    latest_tag = "v1.0.0.0"
-    print("No tags found, starting with newest Hugo release", file=stderr)
-
+    current_url = content["next"]
+    try_next_page = bool(current_url)
 
 auth = b64encode(os.environ["GH_TOKEN"].encode()).decode()
 res = requests.get(ENDPOINT_HUGO_IMAGES, headers={"Authorization": f"Bearer {auth}"})
 
 version_regex = re.compile("v([0-9]+\\.){2}[0-9]+")
-releases_to_process = [
-    tag
+available_tags = set([
+    tag[1:]
     for tag in res.json()["tags"]
-    if version_regex.match(tag) and make_comparable(tag) < make_comparable(latest_tag)
-]
+    if version_regex.match(tag)
+])
+tags_to_process = available_tags - our_tags
 
-print("Found releases:", file=stderr)
-print(releases_to_process, file=stderr)
+print("Unprocessed releases:", file=stderr)
+print(tags_to_process, file=stderr)
 
-if releases_to_process:
-    minimum_new_version = max(releases_to_process, key=make_comparable)
-    print("Preparing image for", minimum_new_version, file=stderr)
+if tags_to_process:
+    maximum_new_version = max(tags_to_process, key=make_comparable)
+    print("Preparing image for", maximum_new_version, file=stderr)
 else:
-    minimum_new_version = "NONE"
+    maximum_new_version = "NONE"
     print("No new release found, stopping.", file=stderr)
 
-print("version=", minimum_new_version.replace("v", ""), sep="")
+print("version=", maximum_new_version, sep="")

--- a/get_latest_new_release.py
+++ b/get_latest_new_release.py
@@ -1,0 +1,59 @@
+import requests
+
+def make_comparable(version_string: str) -> list[int]:
+    return [int(part) for part in version_string.replace("v", "").split(".")]
+
+ENDPOINT_HUGO_RELEASES = "https://api.github.com/repos/gohugoio/hugo/releases"
+ENDPOINT_MY_TAGS = "https://api.github.com/repos/irgendwr/docker-hugo/tags?per_page=1"
+
+request_counter = 1
+
+# Check the latest release we've done
+res = requests.get(ENDPOINT_MY_TAGS)
+try:
+    latest_tag = res.json()[0]["name"]
+except IndexError:
+    latest_tag = "v0.88.1"
+print("Checking for releases younger than", latest_tag)
+
+releases_to_process = []
+try_next_page = True
+current_url = ENDPOINT_HUGO_RELEASES
+while try_next_page:
+    print("Retrieving releases at", current_url)
+    if request_counter < 10:
+        res = requests.get(current_url)
+    else:
+        print("Reached 10 requests")
+        exit(1)
+    request_counter += 1
+    content = res.json()
+    for release in content:
+        # Only check next page if the last release was still newer than our latest
+        try_next_page = False
+        if make_comparable(latest_tag) < make_comparable(release["name"]):
+            try_next_page = True
+            # Remove the "v" at the start of the tag name
+            releases_to_process.append(release["name"][1:])
+        
+    if try_next_page:
+        # Retrieve link to next page from Link header
+        pagination_urls = res.headers["Link"]
+        for element in pagination_urls.split(","):
+            if 'rel="next"' in element:
+                current_url = element.split(">")[0].split("<")[1]
+                break
+
+print("Found releases:")
+print(releases_to_process)
+
+if releases_to_process:
+    minimum_new_version = min(releases_to_process, key=make_comparable)
+    print("Preparing image for", minimum_new_version)
+else:
+    minimum_new_version = "NONE"
+    print("No new release found, stopping.")
+
+with open("_version.txt", "w") as f:
+    f.write(minimum_new_version)
+

--- a/get_latest_new_release.py
+++ b/get_latest_new_release.py
@@ -4,7 +4,7 @@ def make_comparable(version_string: str) -> list[int]:
     return [int(part) for part in version_string.replace("v", "").split(".")]
 
 ENDPOINT_HUGO_RELEASES = "https://api.github.com/repos/gohugoio/hugo/releases"
-ENDPOINT_MY_TAGS = "https://api.github.com/repos/irgendwr/docker-hugo/tags?per_page=1"
+ENDPOINT_MY_TAGS = "https://api.github.com/repos/DeinAlptraum/docker-hugo/tags?per_page=1"
 
 request_counter = 1
 

--- a/get_latest_new_release.py
+++ b/get_latest_new_release.py
@@ -1,10 +1,18 @@
 import requests
+import os
+from base64 import b64encode
+import re
+from sys import stderr
+
 
 def make_comparable(version_string: str) -> list[int]:
     return [int(part) for part in version_string.replace("v", "").split(".")]
 
-ENDPOINT_HUGO_RELEASES = "https://api.github.com/repos/gohugoio/hugo/releases"
-ENDPOINT_MY_TAGS = "https://api.github.com/repos/DeinAlptraum/docker-hugo/tags?per_page=1"
+
+ENDPOINT_HUGO_IMAGES = "https://ghcr.io/v2/gohugoio/hugo/tags/list"
+ENDPOINT_MY_TAGS = (
+    "https://api.github.com/repos/DeinAlptraum/docker-hugo/tags?per_page=1"
+)
 
 request_counter = 1
 
@@ -12,48 +20,30 @@ request_counter = 1
 res = requests.get(ENDPOINT_MY_TAGS)
 try:
     latest_tag = res.json()[0]["name"]
+    print("Checking for releases older than", latest_tag, file=stderr)
 except IndexError:
-    latest_tag = "v0.88.1"
-print("Checking for releases younger than", latest_tag)
+    latest_tag = None
+    print("No tags found, starting with newest Hugo release", file=stderr)
 
-releases_to_process = []
-try_next_page = True
-current_url = ENDPOINT_HUGO_RELEASES
-while try_next_page:
-    print("Retrieving releases at", current_url)
-    if request_counter < 10:
-        res = requests.get(current_url)
-    else:
-        print("Reached 10 requests")
-        exit(1)
-    request_counter += 1
-    content = res.json()
-    for release in content:
-        # Only check next page if the last release was still newer than our latest
-        try_next_page = False
-        if make_comparable(latest_tag) < make_comparable(release["name"]):
-            try_next_page = True
-            # Remove the "v" at the start of the tag name
-            releases_to_process.append(release["name"][1:])
-        
-    if try_next_page:
-        # Retrieve link to next page from Link header
-        pagination_urls = res.headers["Link"]
-        for element in pagination_urls.split(","):
-            if 'rel="next"' in element:
-                current_url = element.split(">")[0].split("<")[1]
-                break
 
-print("Found releases:")
-print(releases_to_process)
+auth = b64encode(os.environ["GH_TOKEN"].encode()).decode()
+res = requests.get(ENDPOINT_HUGO_IMAGES, headers={"Authorization": f"Bearer {auth}"})
+
+version_regex = re.compile("v([0-9]+\\.){2}[0-9]+")
+releases_to_process = [
+    tag
+    for tag in res.json()["tags"]
+    if version_regex.match(tag) and make_comparable(tag) < make_comparable(latest_tag)
+]
+
+print("Found releases:", file=stderr)
+print(releases_to_process, file=stderr)
 
 if releases_to_process:
-    minimum_new_version = min(releases_to_process, key=make_comparable)
-    print("Preparing image for", minimum_new_version)
+    minimum_new_version = max(releases_to_process, key=make_comparable)
+    print("Preparing image for", minimum_new_version, file=stderr)
 else:
     minimum_new_version = "NONE"
-    print("No new release found, stopping.")
+    print("No new release found, stopping.", file=stderr)
 
-with open("_version.txt", "w") as f:
-    f.write(minimum_new_version)
-
+print(minimum_new_version.replace("v", ""))

--- a/get_latest_new_release.py
+++ b/get_latest_new_release.py
@@ -36,7 +36,7 @@ auth = b64encode(os.environ["GH_TOKEN"].encode()).decode()
 res = requests.get(ENDPOINT_HUGO_IMAGES, headers={"Authorization": f"Bearer {auth}"})
 
 available_tags = set(
-    [tag[1:] for tag in res.json()["tags"] if version_regex.match(tag)]
+    [tag[1:] for tag in res.json()["tags"] if version_regex.search(tag)]
 )
 tags_to_process = available_tags - our_tags
 

--- a/get_latest_new_release.py
+++ b/get_latest_new_release.py
@@ -50,4 +50,4 @@ else:
     maximum_new_version = "NONE"
     print("No new release found, stopping.", file=stderr)
 
-print("version=", maximum_new_version, sep="")
+print(f"version={maximum_new_version}")


### PR DESCRIPTION
This adds a Python script to extract via the Github API the most recent Hugo release that has not yet had a branch/image created, and a Github Actions CI that updates the Dockerfile to that version version, creates a branch and tag, and builds and pushes a new Docker image to the hub. 

The CI job runs once per day, cancelling itself if no new release has been found.